### PR TITLE
Undo removal of encrypted fields.

### DIFF
--- a/modules/ModuleBuilder/language/en_us.lang.php
+++ b/modules/ModuleBuilder/language/en_us.lang.php
@@ -719,6 +719,7 @@ $mod_strings = array(
         'url' => 'URL',
         'iframe' => 'IFrame',
         'datetimecombo' => 'Datetime',
+        'encrypt'=>'Encrypt',
         'decimal' => 'Decimal',
         'image' => 'Image',
     ),


### PR DESCRIPTION
Encrypt was removed after version 6.0.4 of SugarCRM the Community Edition.
It's important to have it back, since banking information, health information, and other sensitive data, are required by law in most countries to be encrypted, so as to protect them from theft by hackers and evil sysadmins.
