### PR TITLE
More fixes for #905 require custom/ crashes app.

### DIFF
--- a/include/social/twitter/twitterapi.php
+++ b/include/social/twitter/twitterapi.php
@@ -10,7 +10,7 @@
  */
 
 require_once('include/social/twitter/twitter_auth/twitteroauth/twitteroauth.php');
-require_once('custom/modules/Connectors/connectors/sources/ext/rest/twitter/config.php');
+require_once('modules/Connectors/connectors/sources/ext/rest/twitter/config.php');
 require_once('include/social/twitter/twitter_helper.php');
 
 global $sugar_config, $db;


### PR DESCRIPTION
Twitter connector has moved out of custom/modules and into modules/.
Require_once was including from custom/modules and crashed the app.