### PR TITLE
Fix #10282 Campaign Response by Recipient Activity has recently become unreliable.

### DIFF
--- a/modules/EmailMan/EmailManDelivery.php
+++ b/modules/EmailMan/EmailManDelivery.php
@@ -44,7 +44,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
 
 require_once 'include/SugarPHPMailer.php';
 
-global $sugar_config;
+global $sugar_config, $log;
 
 $configurator = new Configurator();
 $confirmOptInEnabled = $configurator->isConfirmOptInEnabled();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->
With this I implement  [RFC8085, "Signaling One-Click Functionality for List Email Headers"](https://datatracker.ietf.org/doc/html/rfc8058) to protect the accuracy of SuiteCRM opt-out feature for Newsletters and Email Campaigns, by preventing email services from opting-out subscribers unintentionally when crawling links in the email message looking for web sites with malware to  block.

All major email services (Microsoft, Gmail, Yahoo, etc) are crawling the links in email messages, to protect users from malware, and that crawling has been triggering the unsubscribe ("opt-out") feature, the "Remove Me" link in the footer of every Campaign and Newsletter bulk email message.

The new way, required in 2024, is to have headers in the email, telling the email client app exactly which URL to request with a POST action, which does a one-click unsubscribe ("opt-out"), for the subscriber, for this particular email campaign or newsletter.  So the subscriber no longer has to leave their email client app, visit the Remove Me web page on the CRM, or even click a button to unsubscribe.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
1. Improve reliability in detecting the web app's URL, in case the admin has left 'site_url' blank. This is required for constructing the opt-out URL.
2. Fix some missing global statements for `$log` and `$mod_strings`.
3. Accurantly construct the headers required for RFC8085 one-click unsubscribe.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The top Email services have been crawling all the links in the Campaign and Newsletter emails for a long time.  One load of the opt-out (unsubscribe) link was actually unsubscribing every single lead or target who received the email, before they could even open it and read it!

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Without this Fix, try sending a Campaign or Newsletter to only gmail, yahoo, or microsoft hosted email address.  All of your emails will unsubsribe immediately.  That's the automated link scanners loading the opt-out link to check for malware!

Apply this Fix.  Send a Campaign or Newsletter to only Gmail, Yahoo, and Microsoft hosted emil.  The headers for RFC8085 should be present, and none of the recipients will unsubscribe until they have a chance to open up the email message and look at it.

In Progress, and probably done by the time you read this: modifying Entry Point to only opt-out (unsubscribe) the user when the HTTP request for "removeme" comes in as a POST.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->